### PR TITLE
[#32] selection을 하면 같은 노드를 같이 select 해주는 기능 추가

### DIFF
--- a/LabDuck/View/TableView.swift
+++ b/LabDuck/View/TableView.swift
@@ -16,6 +16,8 @@ struct TableView: View {
     @State var edges: [KPEdge] = [
         KPEdge(sourceID: Array.mockData[0].outputPoints[0].id, sinkID: Array.mockData[1].inputPoints[0].id),
         KPEdge(sourceID: Array.mockData[0].outputPoints[0].id, sinkID: Array.mockData[3].inputPoints[0].id),
+        KPEdge(sourceID: Array.mockData[0].outputPoints[0].id, sinkID: Array.mockData[4].inputPoints[0].id),
+        KPEdge(sourceID: Array.mockData[0].outputPoints[0].id, sinkID: Array.mockData[3].inputPoints[1].id),
     ]
     
     var body: some View {
@@ -66,15 +68,19 @@ struct TableView: View {
                         TableRow(node)
                     } else {
                         DisclosureTableRow(node) {
-                            ForEach(findNodes(matching: node))
+                            ForEach(findNodes(matching: node).sorted(using: sortOrder)) { subNode in
+                                TableRow(subNode)
+                            }
                         }
                     }
                 }
             }
             .tableStyle(.inset(alternatesRowBackgrounds: false))
             .scrollContentBackground(.hidden)
-            .onChange(of: sortOrder) { newOrder in
-                nodes.sort(using: newOrder) }
+            .onChange(of: sortOrder) { _, newSortOrder in
+                nodes.sort(using: newSortOrder)}
+            .onChange(of: selection) { _, newSelection in
+                updateSelection(newSelection: newSelection)}
         }
     }
     // MARK: - 노드의 ouputPoint에 대한 inputPoint들을 찾아 해당 노드들 리턴
@@ -95,7 +101,18 @@ struct TableView: View {
         
         return Array(nodeDict.values)
     }
-    
+    // MARK: - selection된 리스트를 받아서 같은 id인 것들을 업데이트
+    func updateSelection(newSelection: Set<KPNode.ID>) {
+        var allSelectedIDs = newSelection
+        
+        newSelection.forEach { nodeID in
+            if let node = nodes.first(where: { $0.id == nodeID }) {
+                allSelectedIDs.insert(node.id)
+            }
+        }
+        
+        selection = allSelectedIDs
+    }
 }
 
 #Preview {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- selection 시에 상위, 하위 테이블에 있는 같은 노드를 같이 select 해주는 기능 추가


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #32 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- selection 기능을 추가한 이후에 select를 하면 하위테이블의 순서가 계속 바뀌는 문제가 발생했습니다. 이 부분은`ForEach(findNodes(matching: node).sorted(using: sortOrder))` 로 하위 테이블은 정렬을 시켜서 뷰를 만드는 방식으로 해결했는데 더 좋은 방법이 있다면 알려주세요!!

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->


https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M08-LabDuck/assets/63441374/f3222e74-30c9-4869-858f-e7f33d5bc54a

