### PR TITLE
[#40] 노드 위에 마우스를 올렸을 때 확대 축소시 노드 이동 관련 pr

### DIFF
--- a/LabDuck.xcodeproj/project.pbxproj
+++ b/LabDuck.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		6F9D09C92BEDC29500159BFC /* LabDuckApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9D09C82BEDC29500159BFC /* LabDuckApp.swift */; };
 		6F9D09CD2BEDC29700159BFC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F9D09CC2BEDC29700159BFC /* Assets.xcassets */; };
 		6F9D09D02BEDC29700159BFC /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F9D09CF2BEDC29700159BFC /* Preview Assets.xcassets */; };
+		988282102BF6E85800BF29B8 /* HoverState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9882820F2BF6E85800BF29B8 /* HoverState.swift */; };
 		BD57969D2BF1F2AC0023A92C /* TableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD57969C2BF1F2AC0023A92C /* TableView.swift */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +60,7 @@
 		6F9D09CC2BEDC29700159BFC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6F9D09CF2BEDC29700159BFC /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		6F9D09D12BEDC29700159BFC /* LabDuck.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LabDuck.entitlements; sourceTree = "<group>"; };
+		9882820F2BF6E85800BF29B8 /* HoverState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverState.swift; sourceTree = "<group>"; };
 		BD57969C2BF1F2AC0023A92C /* TableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -110,6 +112,7 @@
 				6F050B272BF1ACA0003D54BD /* DraggableViewModifier.swift */,
 				6F050B422BF348A0003D54BD /* CGPoint+Operators.swift */,
 				6F050B442BF37D4B003D54BD /* CGRect+center.swift */,
+				9882820F2BF6E85800BF29B8 /* HoverState.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -246,6 +249,7 @@
 				6F050B242BF1AC30003D54BD /* KPNode.swift in Sources */,
 				6F050B382BF1BEEF003D54BD /* KPText.swift in Sources */,
 				6F050B302BF1BDDD003D54BD /* KPColorTheme.swift in Sources */,
+				988282102BF6E85800BF29B8 /* HoverState.swift in Sources */,
 				6F050B282BF1ACA0003D54BD /* DraggableViewModifier.swift in Sources */,
 				6F050B3C2BF302F5003D54BD /* OutputPointView.swift in Sources */,
 				6F050B222BF1AC08003D54BD /* GraphView.swift in Sources */,

--- a/LabDuck/Util/DraggableViewModifier.swift
+++ b/LabDuck/Util/DraggableViewModifier.swift
@@ -6,19 +6,26 @@
 //
 
 import SwiftUI
+import Combine
+
+
 
 struct DraggableViewModifier: ViewModifier {//바인딩으로 전달. false면 반영 ture면 반영 안하기.
     @Binding var offset: CGPoint
     //@Binding var zoomstate: Bool
-
+    //@State private var isHovering = true
+    //@Binding var isHovering: Bool
     //드래그된 뷰의 위치를 저장.
+    @ObservedObject var hoverState: HoverState
 
     func body(content: Content) -> some View {
         content.gesture(DragGesture(minimumDistance: 0)
                 .onChanged { value in
                     print(value)
-                    self.offset.x += value.location.x - value.startLocation.x
-                    self.offset.y += value.location.y - value.startLocation.y
+                    if hoverState.isHover == false { //여기 확대 축소와 관련된 것 같음
+                        self.offset.x += value.location.x - value.startLocation.x
+                        self.offset.y += value.location.y - value.startLocation.y
+                    }
                 })
             .offset(x: offset.x, y: offset.y)
     }

--- a/LabDuck/Util/HoverState.swift
+++ b/LabDuck/Util/HoverState.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+import SwiftUI
+
+class HoverState: ObservableObject {
+    @Published var isHover: Bool = false
+}

--- a/LabDuck/Util/View+draggable.swift
+++ b/LabDuck/Util/View+draggable.swift
@@ -9,6 +9,6 @@ import SwiftUI
 
 extension View {
     func draggable(offset: Binding<CGPoint>) -> some View {
-        return modifier(DraggableViewModifier(offset: offset))
+        return modifier(DraggableViewModifier(offset: offset, hoverState: HoverState()))
     }
 }

--- a/LabDuck/View/GraphView.swift
+++ b/LabDuck/View/GraphView.swift
@@ -13,6 +13,10 @@ struct GraphView: View {
     @State private var outputPointRects: [KPOutputPoint.ID : CGRect] = [:]
 
     @State private var previewEdge: (CGPoint, CGPoint)? = nil
+    
+    //@State private var isHovering = false
+    //@StateObject private var hoverState = HoverState()
+
     var body: some View {
         ZStack {
             ForEach(board.edges) { edge in
@@ -28,9 +32,11 @@ struct GraphView: View {
             ForEach(self.$board.nodes) { node in
                 NodeView(
                     node: node,
+                    hoverState :HoverState(),
                     judgeConnection: self.judgeConnection(outputID:dragLocation:),
                     addEdge: self.addEdge(edge:),
                     updatePreviewEdge: self.updatePreviewEdge(from:to:)
+
                 )
             }
             if let previewEdge {

--- a/LabDuck/View/MainView.swift
+++ b/LabDuck/View/MainView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import Combine
 
-
+//isHovering 마우스 올리면 true , 마우스 떼면 false로 설정
 
 struct MainView: View {
     @State private var zoom = 1.0
@@ -17,7 +17,9 @@ struct MainView: View {
     @GestureState private var gestureDrag = CGSize.zero
     
     //@Binding private var zoomstate : Bool
-    //@State private var zoomstate: Bool
+    @State var zoomstate = false //기본값
+
+    @State private var isHovering = false
 
     @State var subs = Set<AnyCancellable>() // Cancel onDisappear
     var body: some View {
@@ -30,26 +32,38 @@ struct MainView: View {
         .gesture(
             MagnifyGesture()// 업데이트가 되고 있는 상태. zoom하고 있는 상태를 ture로 바꾸고, end가 되면 false로 바꿔주기.
                 .updating($gestureZoom) { value, gestureState, _ in
-//                    print(value.magnification)
+                    print(value.magnification)
                     if value.magnification > 0 {
                         gestureState = value.magnification
+                        zoomstate = true
                     }
                     //zoomstate = true
                 }
                 .onEnded { value in
                     if value.magnification > 0 {
                         zoom *= value.magnification
+                        zoomstate = false
+
                     }
                     //zoomstate = false
                 }
         )
+        
+        
+        
         .gesture(
             DragGesture()
                 .updating($gestureDrag) { value, gestureState, _ in
-                    gestureState = value.translation
+                    //if isHovering == false {
+                    //    print("asdfasdfasdf", isHovering)
+                        gestureState = value.translation
+                    //}
                 }
                 .onEnded { value in
-                    dragOffset += value.translation
+                    //if isHovering == true {
+                    //    print("asdfasdfasdf", isHovering)
+                        dragOffset += value.translation
+                    //}
                 }
         )
         .onAppear {
@@ -70,6 +84,6 @@ struct MainView: View {
     }
 }
 
-#Preview {
-    MainView()
-}
+//#Preview {
+//    MainView()
+//}

--- a/LabDuck/View/NodeView.swift
+++ b/LabDuck/View/NodeView.swift
@@ -6,22 +6,42 @@
 //
 
 import SwiftUI
+import Combine
 
 struct NodeView: View {
     @Binding var node: KPNode
     @State private var dragLocation: CGPoint?
     @State private var currentOutputPoint: KPOutputPoint.ID?
+    //@State private var isHovering = false
+   // @Binding var isHovering: Bool // 바인딩으로 전달 받음
+
     var judgeConnection: (_ outputID: KPOutputPoint.ID, _ dragLocation: CGPoint) -> (KPOutputPoint.ID, KPInputPoint.ID)?
     var addEdge: (_ edge: KPEdge) -> ()
     var updatePreviewEdge: (_ sourceID: KPOutputPoint.ID, _ dragPoint: CGPoint?) -> ()
 
+    
+    //ObservableObject 클래스 정의
+    class HoverState: ObservableObject {
+        @Published var isHover: Bool = false
+    }
+    
+    //HoverState 사용
+    @ObservedObject var hoverState: HoverState
+    
     var body: some View {
         HStack {
             VStack {
                 ForEach(node.inputPoints) { inputPoint in
                     InputPointView(inputPoint: inputPoint)
                 }
+            }.onHover { 
+                hovering in
+                self.hoverState.isHover = hovering //마우스가 닿아있으면 true
+                //isHovering = true
+                //print(isHovering)
+                print("11111111111111")
             }
+            //.background(isHovering ? Color.blue : Color.red)
             VStack {
                 Text("asdf")
                 Text(node.unwrappedTitle)
@@ -29,6 +49,12 @@ struct NodeView: View {
                 if let dragLocation {
                     Text("\(dragLocation.y.rounded()), \(dragLocation.x.rounded())")
                 }
+            }.onHover {
+                hovering in
+                self.hoverState.isHover = hovering //마우스가 닿아있으면 true
+//                isHovering = true
+//                print(isHovering)
+                print("222222222222222")
             }
             VStack {
                 ForEach(node.outputPoints) { outputPoint in
@@ -54,6 +80,12 @@ struct NodeView: View {
                                 }
                         )
                 }
+            }.onHover {
+                hovering in
+                self.hoverState.isHover = hovering //마우스가 닿아있으면 true
+//                isHovering = true
+//                print(isHovering)
+                print("33333333333333")
             }
         }
         .padding()
@@ -61,6 +93,13 @@ struct NodeView: View {
         .border(Color.black, width: 2.0)
         .frame(maxWidth: 250, maxHeight: 50)
         .draggable(offset: $node.position)
+        .onHover {
+            hovering in
+            self.hoverState.isHover = hovering //마우스가 닿아있으면 true
+//            isHovering = true
+//            print(isHovering)
+            print("4444444444444444")
+        }
     }
 
     private func judgeConnection(with location: CGPoint) -> (KPOutputPoint.ID, KPInputPoint.ID)? {
@@ -72,6 +111,6 @@ struct NodeView: View {
     }
 }
 
-#Preview {
-    NodeView(node: .constant(.mockData), judgeConnection: { _, _ in (UUID(), UUID()) }, addEdge: { _ in }, updatePreviewEdge: { _, _ in })
-}
+//#Preview {
+//    NodeView(node: .constant(.mockData), judgeConnection: { _, _ in (UUID(), UUID()) }, addEdge: { _ in }, updatePreviewEdge: { _, _ in })
+//}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 진행사항 공유용 PR입니다
- 여러 방법 사용해서 진행해 보다가 현재는 HoverState라는 파일 생성 후, class HoverState: ObservableObject 등을 활용해서 해보고 있는 중인데 아직 수정되지 않은 상태입니다.



## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #40 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 마우스가 노드 위에 있을 때도 작동하는 것이 문제인 것 같아 멘토분께도 질문했더니 맞는 것 같다고 하신 상태입니다. 두개의 효과가 동시에 작동하고 있다는 것이 문제인 것으로 멘토분과 이야기 하였는데, 혹시 다른 방법으로 해결 가능하거나, 해결하셨으면 말씀해주세요.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

