### PR TITLE
[#89] 태그 삭제 기능, 프리뷰 있을 때만 노출, 태그 색 반영(랜덤)

### DIFF
--- a/LabDuck/Model/KPNode.swift
+++ b/LabDuck/Model/KPNode.swift
@@ -82,7 +82,7 @@ extension Array where Element == KPNode {
             title: "Thrilled by Your Progress! Large Language Models (GPT-4) No Longer Struggle to Pass Assessments in Higher Education Programming Courses",
             note: "Related work 살펴보기 좋을듯 Related work 살펴보기 좋을듯 Related work 살펴보기 좋을듯 Related work 살펴보기 좋을듯 Related work 살펴보기 좋을듯 Related work 살펴보기 좋을듯",
             url: "https://arxiv.org/pdf/2306.10073.pdf",
-            tags: [KPTag.mockData, KPTag.mockData1, KPTag.mockData2, KPTag.mockData2, KPTag.mockData2],
+            tags: [KPTag.mockData, KPTag.mockData1],
             colorTheme: .blue,
             position: .init(x: 50, y: 20),
             inputPoints: .mockData,

--- a/LabDuck/Model/KPTagColor.swift
+++ b/LabDuck/Model/KPTagColor.swift
@@ -46,3 +46,9 @@ enum KPTagColor: CaseIterable {
     }
 }
 
+extension KPTagColor {
+    static func random() -> KPTagColor {
+        return KPTagColor.allCases.randomElement()!
+    }
+}
+

--- a/LabDuck/View/NodeView.swift
+++ b/LabDuck/View/NodeView.swift
@@ -64,7 +64,6 @@ struct NodeView: View {
                                 ForEach(KPColorTheme.allCases, id: \.self) { colorTheme in
                                     Button(action: {
                                         node.colorTheme = colorTheme
-                                        //                                        selectedButtonIndex = index
                                     }) {
                                         ZStack{
                                             RoundedRectangle(cornerRadius: 3)
@@ -239,8 +238,8 @@ struct NodeView: View {
                                     ForEach(node.tags){ tag in
                                         Text("#\(tag.name)")
                                             .foregroundColor(.white)
-                                            .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
-                                            .background(Color.blue)
+                                            .padding(EdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8))
+                                            .background(tag.colorTheme.backgroundColor)
                                             .cornerRadius(10)
                                         
                                     }
@@ -256,8 +255,8 @@ struct NodeView: View {
                                 ForEach(node.tags){ tag in
                                     Text("#\(tag.name)")
                                         .foregroundColor(.white)
-                                        .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
-                                        .background(Color.blue)
+                                        .padding(EdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8))
+                                        .background(tag.colorTheme.backgroundColor)
                                         .cornerRadius(10)
                                     
                                 }
@@ -352,6 +351,6 @@ struct NodeView: View {
 }
 
 
-//#Preview {
-//    NodeView(node: .constant(.mockData), clickingOutput: <#Binding<Bool>#>, isEditingForTitle: isEditingForTitle, judgeConnection: { _, _ in (UUID(), UUID()) }, addEdge: { _ in }, updatePreviewEdge: { _, _ in })
-//}
+#Preview {
+    NodeView(node: .constant(.mockData), clickingOutput: .constant(false), judgeConnection: { _, _ in (UUID(), UUID()) }, addEdge: { _ in }, updatePreviewEdge: { _, _ in })
+}

--- a/LabDuck/View/TagPopupView.swift
+++ b/LabDuck/View/TagPopupView.swift
@@ -46,50 +46,74 @@ struct TagPopupView: View {
             
             
             VStack(alignment: .leading, spacing: 10){
-                Text("선택된 태그").foregroundColor(.gray).font(.system(size:13)).padding(10)
-            
-            
-            Text("태그 선택 또는 생성").foregroundColor(.gray).font(.system(size:13)).padding(10)
-                
-                HStack(spacing: 20){
-                    
-                    //태그 생성 버튼
-                    Button{
-                        createTag()
+                if previewTag != nil {
+                    HStack(spacing: 20){
                         
-                    }label: {
-                        Text("생성").foregroundColor(.black)
-                    }.buttonStyle(BorderlessButtonStyle())
-                        .padding(.top, 5)
-                    
-                    //태그 프리뷰
-                    if previewTag != nil {
+                        
+                        //태그 생성 버튼
+                        Button{
+                            createTag()
+                            
+                        }label: {
+                            Text("생성").foregroundColor(.black)
+                        }.buttonStyle(BorderlessButtonStyle())
+                            .padding(.top, 5)
+                        
+                        
+                        
+                        //태그 프리뷰
+                        
                         Text("#\(textForTags)")
                             .padding(8)
-                            .background(.blue)
+                            .background(previewTag!.colorTheme.backgroundColor)
                             .cornerRadius(6)
                             .foregroundColor(.white)
                             .padding(.top, 5)
                         
-                    }
-                    Spacer()
-                    
-                }.background(Color.gray)
-                    .frame(width: 234, height: 40)
-                    .cornerRadius(6)
-                    .padding(10)
-            
+                        
+                        Spacer()
+                        
+                    }.background(Color.gray)
+                        .frame(width: 234, height: 40)
+                        .cornerRadius(6)
+                        .padding(10)
+                }
+                
+                Text("선택된 태그").foregroundColor(.gray).font(.system(size:7)).padding(10)
                 
                 //태그 뷰의 태그 출력
                 VStack(alignment: .leading, spacing: 10) {
                     ForEach(node.tags) { tag in
-                        Text("#\(tag.name)")
-                            .foregroundColor(.white)
-                            .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
-                            .background(Color.blue)
-                            .cornerRadius(6)
+                        HStack{
+                            Text("#\(tag.name)")
+                                .foregroundColor(.white)
+                                .padding(EdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8))
+                                .background(tag.colorTheme.backgroundColor)
+                                .cornerRadius(6)
+                            Spacer()
+                            Button{
+                                deleteTag(tag)
+                            }label: {
+                                Image(systemName: "trash").foregroundColor(.gray)
+                            }.buttonStyle(BorderlessButtonStyle())
+                            
+                        }
                     }
                 }
+                
+                Text("태그 선택 또는 생성").foregroundColor(.gray).font(.system(size:7)).padding(10)
+                
+//                ForEach() { tag in
+//                    HStack{
+//                        Text("#\(tag.name)")
+//                            .foregroundColor(.white)
+//                            .padding(EdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8))
+//                            .background(tag.colorTheme.backgroundColor)
+//                            .cornerRadius(6)
+//                        Spacer()
+//                    }
+//                }
+                
             }
             .frame(width:250)
             .background(Color.white)
@@ -100,7 +124,7 @@ struct TagPopupView: View {
     
     private func addPreviewTag() {
         guard !textForTags.isEmpty else { return }
-        let newTagForPreview = KPTag(id: UUID(), name: textForTags, colorTheme: KPTagColor.blue)
+        let newTagForPreview = KPTag(id: UUID(), name: textForTags, colorTheme: KPTagColor.random())
         previewTag = newTagForPreview
     }
     
@@ -109,5 +133,10 @@ struct TagPopupView: View {
         node.tags.append(previewTag)
         self.previewTag = nil
         self.textForTags = ""
+    }
+    private func deleteTag(_ tag: KPTag) {
+        if let index = node.tags.firstIndex(where: { $0.id == tag.id }) {
+            node.tags.remove(at: index)
+        }
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

 1. 태그 삭제 기능
 2. 프리뷰 있을 때만 노출
 3. 태그 색 반영(랜덤)

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #89 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
 전체 노드 태그 정보 불러오기
 태그 순서 변화
 전체 노드 태그와 작성한 태그가 겹치면 생성 불가
를 구현하고 있습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M08-LabDuck/assets/160375101/d0863ff7-7cd8-49d7-ad07-0ac6f9edfe74



