### PR TITLE
[#105] 노드 삭제시 팝업 기능

### DIFF
--- a/LabDuck/View/EditSheetView.swift
+++ b/LabDuck/View/EditSheetView.swift
@@ -10,7 +10,7 @@ struct EditSheetView: View {
     @State private var relatedNodes: [KPNode] = []
     @State private var isEditingForTag: Bool = false
     let findNodes: (KPNode) -> [KPNode]
-//    @Binding var uniqueTags: [KPTag]
+    //    @Binding var uniqueTags: [KPTag]
     
     var body: some View {
         VStack {
@@ -46,10 +46,12 @@ struct EditSheetView: View {
             
             Button(action: {
                 document.removeNode(node.id, undoManager: undoManager, animation: .default)
+
             }) {
                 Image(systemName: "trash")
                     .frame(width: 20, height: 20)
             }
+            
             
             Button(action: {
                 isSheet = false
@@ -209,7 +211,7 @@ struct EditSheetView: View {
                             .padding(3)
                         if colorTheme == .default {
                             RoundedRectangle(cornerRadius: 3)
-                                .stroke(.black.opacity(0.1), lineWidth: 1)
+                                .stroke(.black.opacity(0.2), lineWidth: 1)
                                 .frame(width: 16, height: 16)
                                 .padding(3)
                         }
@@ -245,8 +247,8 @@ struct EditSheetView: View {
             .font(Font.custom("SF Pro", size: fontSize))
             .frame(height: height)
             .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                    .stroke(Color.black.opacity(0.1), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color.black.opacity(0.2), lineWidth: 1)
             )
     }
     

--- a/LabDuck/View/NodeView.swift
+++ b/LabDuck/View/NodeView.swift
@@ -40,6 +40,8 @@ struct NodeView: View {
     @State private var resizeOffset: CGPoint = .zero
     @State private var isNodeHovered: Bool = false
     
+    @State private var showAlert = false
+    
     var judgeConnection: (_ outputID: KPOutputPoint.ID, _ dragLocation: CGPoint) -> (KPOutputPoint.ID, KPInputPoint.ID)?
     var updatePreviewEdge: (_ sourceID: KPOutputPoint.ID, _ dragPoint: CGPoint?) -> ()
     
@@ -127,7 +129,9 @@ struct NodeView: View {
                         .frame(maxHeight: 28)
 
                     Button {
-                        document.removeNode(node.id, undoManager: undoManager, animation: .default)
+                        print("버튼 클릭")
+                        showAlert = true
+//                        document.removeNode(node.id, undoManager: undoManager, animation: .default)
                     } label: {
                         Image(systemName: "trash")
                             .frame(width: 32, height: 32)
@@ -147,6 +151,13 @@ struct NodeView: View {
                         .stroke(.gray.opacity(0.3), lineWidth: 1)
                 )
                 .padding(4)
+                .confirmationDialog("정말 삭제하시겠습니까?", isPresented: $showAlert, titleVisibility: .visible) {
+                        Button("네", role: .none)
+                        {   print("yes")
+                            document.removeNode(node.id, undoManager: undoManager, animation: .default)
+                        }
+                        Button("아니오", role: .cancel){}
+                    }.dialogSeverity(.critical)
             }
             .frame(minWidth: 50, maxWidth: node.size.width, minHeight: 50, maxHeight: .infinity)
             .shadow(color: .black.opacity(0.25), radius: 1.5, x: 0, y: 0)


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 노드 삭제시 팝업 기능 완료
- 테이블 뷰 또한 추가 예정

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #105 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<img width="629" alt="스크린샷 2024-05-26 오후 7 43 06" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M08-LabDuck/assets/167537498/340344e7-4c39-4d6f-b5f3-34d388cdea4c">


