### PR TITLE
[#99] 간선 삭제 시 inputPoint isLinked 수정 안되는 버그 수정

### DIFF
--- a/LabDuck/Model/KPBoard.swift
+++ b/LabDuck/Model/KPBoard.swift
@@ -51,6 +51,19 @@ struct KPBoard: Identifiable {
         self.edges.removeAll { edge in
             edge.id == edgeID
         }
+        self.checkIsLinked()
+    }
+
+    public mutating func checkIsLinked() {
+        self.nodes.enumerated().forEach { index, node in
+            node.inputPoints.enumerated().forEach { inputPointIndex, inputPoint in
+                if self.edges.contains(where: { $0.sinkID == inputPoint.id }) {
+                    self.nodes[index].inputPoints[inputPointIndex].isLinked = true
+                } else {
+                    self.nodes[index].inputPoints[inputPointIndex].isLinked = false
+                }
+            }
+        }
     }
 
     public mutating func addNode(_ node: KPNode) {

--- a/LabDuck/Model/KPBoardDocument.swift
+++ b/LabDuck/Model/KPBoardDocument.swift
@@ -300,12 +300,11 @@ extension KPBoardDocument {
 
         withAnimation {
             self.board.removeEdge(edgeID)
+            self.board.checkIsLinked()
         }
 
         undoManager?.registerUndo(withTarget: self) { doc in
             doc.replaceEdges(oldEdges, undoManager: undoManager)
-            
-            
         }
     }
 
@@ -313,6 +312,7 @@ extension KPBoardDocument {
         let oldEdges = self.board.edges
 
         self.board.edges = edges
+        self.board.checkIsLinked()
 
         undoManager?.registerUndo(withTarget: self) { doc in
             doc.replaceEdges(oldEdges, undoManager: undoManager, animation: animation)


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
간선 삭제 시 inputPoint isLinked 수정 안되는 버그를 수정했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #99 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

https://github.com/DeveloperAcademy-POSTECH/2024-MC2-M08-LabDuck/assets/19565940/26096c60-4b22-438f-9c7b-c5f9e8651c36


